### PR TITLE
fix: put `EXTRA_CONFIG` before the proxy starts

### DIFF
--- a/3proxy.cfg.mustach
+++ b/3proxy.cfg.mustach
@@ -27,12 +27,13 @@ auth strong
 allow {{ auth.login }}{{#auth.extra_accounts.*}},{{ * }}{{/auth.extra_accounts.*}}
 {{/auth.password=}}{{/auth.login=}}
 
-proxy -a -p{{ ports.proxy }}
-socks -a -p{{ ports.socks }}
-
-flush{{^extra_config=}}
+{{^extra_config=}}
 
 # Additional configuration
 {{extra_config}}
 {{/extra_config=}}
 
+proxy -a -p{{ ports.proxy }}
+socks -a -p{{ ports.socks }}
+
+flush


### PR DESCRIPTION
## Description

<!--

Buddy, first of all, I want to thank you very much for your contribution. I really appreciate it 🤩

Describe briefly what this PR contains and what problem it solves. Please also include relevant motivation and context (list any dependencies that are required for this change, for example)

-->

Fixes #47. See [here](https://github.com/tarampampam/3proxy-docker/issues/47#issuecomment-2020733466). 

Let me know if I should add the entry to the `CHANGELOG.md`, otherwise you can of course edit this PR.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code _(if tests are required for my changes)_ <!-- feel free to drop this item from the list -->
- [ ] I have made changes in the `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `Added` / `Changed` / `Fixed` sections
* Add a reference to the related issue or this PR `[#123](https://github.com/.../.../(issues|pull)/123)`

-->
